### PR TITLE
Improve dev setup and credential handling

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import { ApiKeyForm } from './components/ApiKeyForm';
 import { ChatInterface } from './components/ChatInterface';
 import { Header } from './components/Header';
@@ -24,10 +24,6 @@ const App: React.FC = () => {
     try {
       const data = await fetchWorldData(appKey, authToken, worldId);
       
-      localStorage.setItem('worldAnvilAppKey', appKey);
-      localStorage.setItem('worldAnvilAuthToken', authToken);
-      localStorage.setItem('worldAnvilWorldId', worldId);
-
       setWorldAnvilAppKey(appKey);
       setWorldAnvilAuthToken(authToken);
       setWorldId(worldId);
@@ -56,9 +52,6 @@ const App: React.FC = () => {
   }, []);
   
   const resetKeys = useCallback(() => {
-    localStorage.removeItem('worldAnvilAppKey');
-    localStorage.removeItem('worldAnvilAuthToken');
-    localStorage.removeItem('worldAnvilWorldId');
     setWorldAnvilAppKey('');
     setWorldAnvilAuthToken('');
     setWorldId('');
@@ -67,15 +60,6 @@ const App: React.FC = () => {
     setMessages([]);
     setError(null);
   }, []);
-  
-  useEffect(() => {
-    const storedAppKey = localStorage.getItem('worldAnvilAppKey');
-    const storedAuthToken = localStorage.getItem('worldAnvilAuthToken');
-    const storedWorldId = localStorage.getItem('worldAnvilWorldId');
-    if (storedAppKey && storedAuthToken && storedWorldId) {
-      handleKeysSubmit(storedAppKey, storedAuthToken, storedWorldId);
-    }
-  }, [handleKeysSubmit]);
 
   const handleSendMessage = useCallback(async (question: string) => {
     if (!worldData) {

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ View your app in AI Studio: https://ai.studio/apps/drive/1yl9z2bxrrFsj7P87dVYcvw
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
+2. Start the API/AI server with your Gemini key in the environment:
+   - macOS/Linux: `GEMINI_API_KEY=your-key npm run start`
+   - Windows (PowerShell): `$env:GEMINI_API_KEY='your-key'; npm run start`
+3. In a second terminal, run the Vite dev server:
    `npm run dev`
+
+The Vite server proxies all `/api/*` requests to the Express instance so the chat UI can reach both the Boromir and Gemini endpoints during development.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,12 @@ export default defineConfig(({ mode }) => {
     server: {
       port: 3000,
       host: '0.0.0.0',
+      proxy: {
+        '/api': {
+          target: env.VITE_API_SERVER || 'http://localhost:8080',
+          changeOrigin: true,
+        },
+      },
     },
     plugins: [react()],
     resolve: {


### PR DESCRIPTION
## Summary
- document the correct two-process dev workflow and how to provide `GEMINI_API_KEY`
- add a `/api` proxy to the Vite dev server so frontend requests reach Express during local development
- keep Boromir credentials in memory only so they are no longer persisted in `localStorage`

## Testing
- `npm run build`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d480167ec8333b4441effbb604ea2)